### PR TITLE
Macos update 2024

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,6 @@ bin
 .DS_Store
 debug
 release
-.vscode/
+.vscode/**
 */assimp/**
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "cmake.configureOnOpen": false,
     "files.associations": {
-        "platform.h": "c"
+        "platform.h": "c",
+        "__locale": "c"
     }
 }

--- a/src/examples/GLFW_DynamicDescriptor/textures_dynamic_descriptor.cpp
+++ b/src/examples/GLFW_DynamicDescriptor/textures_dynamic_descriptor.cpp
@@ -15,6 +15,8 @@
 #include <stdint.h>
 #include <assert.h>
 
+#include <string>
+
 #include <GLFW/glfw3.h>
 
 #include <vkal.h>
@@ -80,14 +82,14 @@ void init_window()
 Image load_image_file(char const * file)
 {
     char exe_path[256];
-    get_exe_path(exe_path, 256 * sizeof(char));
-    char abs_path[256];
-    memcpy(abs_path, exe_path, 256);
-    strcat(abs_path, file);
+    get_exe_path(exe_path, 256 * sizeof(char));    
+    // strcat(abs_path, file);
+    std::string finalPath = concat_paths(std::string(exe_path), std::string(file));
+
 
     Image image = { };
     int tw, th, tn;
-    image.data = stbi_load(abs_path, &tw, &th, &tn, 4);
+    image.data = stbi_load(finalPath.c_str(), &tw, &th, &tn, 4);
     assert(image.data != NULL);
     image.width = tw;
     image.height = th;

--- a/src/examples/GLFW_DynamicDescriptor/textures_dynamic_descriptor.cpp
+++ b/src/examples/GLFW_DynamicDescriptor/textures_dynamic_descriptor.cpp
@@ -109,17 +109,22 @@ int main(int argc, char ** argv)
     };
     uint32_t device_extension_count = sizeof(device_extensions) / sizeof(*device_extensions);
 
-    char * instance_extensions[] = {
-	    VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME
-    #ifdef _DEBUG
-	    ,VK_EXT_DEBUG_UTILS_EXTENSION_NAME
-    #endif
+    char* instance_extensions[] = {
+        VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME
+        #ifdef __APPLE__
+            ,VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME
+        #endif
+        #ifdef _DEBUG
+            ,VK_EXT_DEBUG_UTILS_EXTENSION_NAME
+        #endif
     };
     uint32_t instance_extension_count = sizeof(instance_extensions) / sizeof(*instance_extensions);
 
-    char * instance_layers[] = {
-	    "VK_LAYER_KHRONOS_validation", //"VK_LAYER_LUNARG_standard_validation", <- deprecated!
-	    "VK_LAYER_LUNARG_monitor"
+    char* instance_layers[] = {
+        "VK_LAYER_KHRONOS_validation"
+#if defined(WIN32) || defined(WIN32)
+        ,"VK_LAYER_LUNARG_monitor" // Not available on MacOS!
+#endif
     };
     uint32_t instance_layer_count = 0;
 #ifdef _DEBUG

--- a/src/examples/GLFW_DynamicDescriptorTransformUniform/model_loading.cpp
+++ b/src/examples/GLFW_DynamicDescriptorTransformUniform/model_loading.cpp
@@ -124,17 +124,22 @@ int main(int argc, char ** argv)
     };
     uint32_t device_extension_count = sizeof(device_extensions) / sizeof(*device_extensions);
 
-    char * instance_extensions[] = {
+    char* instance_extensions[] = {
         VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME
-#ifdef _DEBUG
-        ,VK_EXT_DEBUG_UTILS_EXTENSION_NAME
-#endif
+        #ifdef __APPLE__
+            ,VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME
+        #endif
+        #ifdef _DEBUG
+            ,VK_EXT_DEBUG_UTILS_EXTENSION_NAME
+        #endif
     };
     uint32_t instance_extension_count = sizeof(instance_extensions) / sizeof(*instance_extensions);
 
-    char * instance_layers[] = {
-        "VK_LAYER_KHRONOS_validation", //"VK_LAYER_LUNARG_standard_validation", <- deprecated!
-        "VK_LAYER_LUNARG_monitor"
+    char* instance_layers[] = {
+        "VK_LAYER_KHRONOS_validation"
+#if defined(WIN32) || defined(WIN32)
+        ,"VK_LAYER_LUNARG_monitor" // Not available on MacOS!
+#endif
     };
     uint32_t instance_layer_count = 0;
 #ifdef _DEBUG

--- a/src/examples/GLFW_HelloTriangle/hello_triangle.cpp
+++ b/src/examples/GLFW_HelloTriangle/hello_triangle.cpp
@@ -73,26 +73,28 @@ int main(int argc, char** argv)
     uint32_t device_extension_count = sizeof(device_extensions) / sizeof(*device_extensions);
 
     char* instance_extensions[] = {
-    VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME,
-    VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME
-#ifdef _DEBUG
-    ,VK_EXT_DEBUG_UTILS_EXTENSION_NAME
-#endif
+        VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME
+        #ifdef __APPLE__
+            ,VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME
+        #endif
+        #ifdef _DEBUG
+            ,VK_EXT_DEBUG_UTILS_EXTENSION_NAME
+        #endif
     };
     uint32_t instance_extension_count = sizeof(instance_extensions) / sizeof(*instance_extensions);
 
     char* instance_layers[] = {
-        "VK_LAYER_KHRONOS_validation",
-        "VK_LAYER_LUNARG_monitor"
+        "VK_LAYER_KHRONOS_validation"
+#if defined(WIN32) || defined(WIN32)
+        ,"VK_LAYER_LUNARG_monitor" // Not available on MacOS!
+#endif
     };
     uint32_t instance_layer_count = 0;
 #ifdef _DEBUG
     instance_layer_count = sizeof(instance_layers) / sizeof(*instance_layers);
 #endif
 
-    printf("vkal_create_instance_glfw...\n");
     vkal_create_instance_glfw(window, instance_extensions, instance_extension_count, instance_layers, instance_layer_count);
-    printf("vkal_create_instance_glfw done.\n");
 
     VkalPhysicalDevice* devices = 0;
     uint32_t device_count;
@@ -110,11 +112,10 @@ int main(int argc, char** argv)
     /* Shader Setup */
     uint8_t* vertex_byte_code = 0;
     int vertex_code_size;
-    read_file("/../src/examples/assets/shaders/hello_triangle_vert.spv", &vertex_byte_code, &vertex_code_size);
-    printf("read_file (vert shader): done.\n");
+    read_file("../../src/examples/assets/shaders/hello_triangle_vert.spv", &vertex_byte_code, &vertex_code_size);
     uint8_t* fragment_byte_code = 0;
     int fragment_code_size;
-    read_file("/../src/examples/assets/shaders/hello_triangle_frag.spv", &fragment_byte_code, &fragment_code_size);
+    read_file("/../../src/examples/assets/shaders/hello_triangle_frag.spv", &fragment_byte_code, &fragment_code_size);
     ShaderStageSetup shader_setup = vkal_create_shaders(vertex_byte_code, vertex_code_size, fragment_byte_code, fragment_code_size);
     
     /* Vertex Input Assembly */
@@ -224,6 +225,7 @@ int main(int argc, char** argv)
 
             vkal_end_command_buffer(image_id);
             VkCommandBuffer command_buffers1[] = { vkal_info->default_command_buffers[image_id] };
+            
             vkal_queue_submit(command_buffers1, 1);
 
             vkal_present(image_id);

--- a/src/examples/GLFW_HelloTriangle/hello_triangle.cpp
+++ b/src/examples/GLFW_HelloTriangle/hello_triangle.cpp
@@ -73,7 +73,8 @@ int main(int argc, char** argv)
     uint32_t device_extension_count = sizeof(device_extensions) / sizeof(*device_extensions);
 
     char* instance_extensions[] = {
-    VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME
+    VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME,
+    VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME
 #ifdef _DEBUG
     ,VK_EXT_DEBUG_UTILS_EXTENSION_NAME
 #endif
@@ -89,7 +90,9 @@ int main(int argc, char** argv)
     instance_layer_count = sizeof(instance_layers) / sizeof(*instance_layers);
 #endif
 
+    printf("vkal_create_instance_glfw...\n");
     vkal_create_instance_glfw(window, instance_extensions, instance_extension_count, instance_layers, instance_layer_count);
+    printf("vkal_create_instance_glfw done.\n");
 
     VkalPhysicalDevice* devices = 0;
     uint32_t device_count;
@@ -107,10 +110,11 @@ int main(int argc, char** argv)
     /* Shader Setup */
     uint8_t* vertex_byte_code = 0;
     int vertex_code_size;
-    read_file("../../src/examples/assets/shaders/hello_triangle_vert.spv", &vertex_byte_code, &vertex_code_size);
+    read_file("/../src/examples/assets/shaders/hello_triangle_vert.spv", &vertex_byte_code, &vertex_code_size);
+    printf("read_file (vert shader): done.\n");
     uint8_t* fragment_byte_code = 0;
     int fragment_code_size;
-    read_file("../../src/examples/assets/shaders/hello_triangle_frag.spv", &fragment_byte_code, &fragment_code_size);
+    read_file("/../src/examples/assets/shaders/hello_triangle_frag.spv", &fragment_byte_code, &fragment_code_size);
     ShaderStageSetup shader_setup = vkal_create_shaders(vertex_byte_code, vertex_code_size, fragment_byte_code, fragment_code_size);
     
     /* Vertex Input Assembly */

--- a/src/examples/GLFW_ImGUI/hello_imgui.cpp
+++ b/src/examples/GLFW_ImGUI/hello_imgui.cpp
@@ -186,6 +186,7 @@ int main(int argc, char** argv)
 
     init_imgui(vkal_info);
 
+#if 0
     /* Compile Shaders at runtime */
     uint8_t * vertex_byte_code = 0;
     int vertex_code_size = 0;
@@ -196,7 +197,7 @@ int main(int argc, char** argv)
     load_glsl_and_compile("../../src/examples/assets/shaders/hello_triangle.frag", &fragment_byte_code, &fragment_code_size, SHADER_TYPE_FRAGMENT);
 
     /* Shader Setup */
-#if 0
+#else
     uint8_t* vertex_byte_code = 0;
     int vertex_code_size;
     read_file("/../../src/examples/assets/shaders/hello_triangle_vert.spv", &vertex_byte_code, &vertex_code_size);

--- a/src/examples/GLFW_ImGUI/hello_imgui.cpp
+++ b/src/examples/GLFW_ImGUI/hello_imgui.cpp
@@ -153,16 +153,21 @@ int main(int argc, char** argv)
     uint32_t device_extension_count = sizeof(device_extensions) / sizeof(*device_extensions);
 
     char* instance_extensions[] = {
-    VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME
-#ifdef _DEBUG
-    ,VK_EXT_DEBUG_UTILS_EXTENSION_NAME
-#endif
+        VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME
+        #ifdef __APPLE__
+            ,VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME
+        #endif
+        #ifdef _DEBUG
+            ,VK_EXT_DEBUG_UTILS_EXTENSION_NAME
+        #endif
     };
     uint32_t instance_extension_count = sizeof(instance_extensions) / sizeof(*instance_extensions);
 
     char* instance_layers[] = {
-        "VK_LAYER_KHRONOS_validation",
-        "VK_LAYER_LUNARG_monitor"
+        "VK_LAYER_KHRONOS_validation"
+#if defined(WIN32) || defined(WIN32)
+        ,"VK_LAYER_LUNARG_monitor" // Not available on MacOS!
+#endif
     };
     uint32_t instance_layer_count = 0;
 #ifdef _DEBUG

--- a/src/examples/GLFW_MultipleTexturesNaive/textures.cpp
+++ b/src/examples/GLFW_MultipleTexturesNaive/textures.cpp
@@ -149,13 +149,13 @@ int main(int argc, char ** argv)
     /* Shader Setup */
     uint8_t * vertex_byte_code = 0;
     int vertex_code_size;
-    read_file("/../src/examples/assets/shaders/textures_vert.spv", &vertex_byte_code, &vertex_code_size);
+    read_file("../../src/examples/assets/shaders/textures_vert.spv", &vertex_byte_code, &vertex_code_size);
     uint8_t * fragment_byte_code = 0;
     int fragment_code_size;
-    read_file("/../src/examples/assets/shaders/textures_frag.spv", &fragment_byte_code, &fragment_code_size);
+    read_file("../../src/examples/assets/shaders/textures_frag.spv", &fragment_byte_code, &fragment_code_size);
     ShaderStageSetup shader_setup = vkal_create_shaders(
-	vertex_byte_code, vertex_code_size, 
-	fragment_byte_code, fragment_code_size);
+	    vertex_byte_code, vertex_code_size, 
+	    fragment_byte_code, fragment_code_size);
 
     /* Vertex Input Assembly */
     VkVertexInputBindingDescription vertex_input_bindings[] =
@@ -244,11 +244,11 @@ int main(int argc, char ** argv)
     uint32_t offset_indices  = vkal_index_buffer_add(rect_indices, index_count);
 
     /* Texture Data */
-    Image image = load_image_file("/../src/examples/assets/textures/vklogo.jpg");
+    Image image = load_image_file("../../src/examples/assets/textures/vklogo.jpg");
     VkalTexture texture = vkal_create_texture(0, image.data, image.width, image.height, 4, 0,
 					  VK_IMAGE_VIEW_TYPE_2D, VK_FORMAT_R8G8B8A8_UNORM, 0, 1, 0, 1, VK_FILTER_LINEAR, VK_FILTER_LINEAR,
 					  VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER);
-    Image image2 = load_image_file("/../src/examples/assets/textures/hk.jpg");
+    Image image2 = load_image_file("/../../src/examples/assets/textures/hk.jpg");
     VkalTexture texture2 = vkal_create_texture(0, image2.data, image2.width, image2.height, 4, 0,
 					   VK_IMAGE_VIEW_TYPE_2D, VK_FORMAT_R8G8B8A8_UNORM, 0, 1, 0, 1, VK_FILTER_LINEAR, VK_FILTER_LINEAR,
 					   VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER);

--- a/src/examples/GLFW_MultipleTexturesNaive/textures.cpp
+++ b/src/examples/GLFW_MultipleTexturesNaive/textures.cpp
@@ -110,7 +110,8 @@ int main(int argc, char ** argv)
     uint32_t device_extension_count = sizeof(device_extensions) / sizeof(*device_extensions);
 
     char * instance_extensions[] = {
-	VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME
+	VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME,
+    VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME
 #ifdef _DEBUG
 	,VK_EXT_DEBUG_UTILS_EXTENSION_NAME
 #endif
@@ -148,10 +149,10 @@ int main(int argc, char ** argv)
     /* Shader Setup */
     uint8_t * vertex_byte_code = 0;
     int vertex_code_size;
-    read_file("../../src/examples/assets/shaders/textures_vert.spv", &vertex_byte_code, &vertex_code_size);
+    read_file("/../src/examples/assets/shaders/textures_vert.spv", &vertex_byte_code, &vertex_code_size);
     uint8_t * fragment_byte_code = 0;
     int fragment_code_size;
-    read_file("../../src/examples/assets/shaders/textures_frag.spv", &fragment_byte_code, &fragment_code_size);
+    read_file("/../src/examples/assets/shaders/textures_frag.spv", &fragment_byte_code, &fragment_code_size);
     ShaderStageSetup shader_setup = vkal_create_shaders(
 	vertex_byte_code, vertex_code_size, 
 	fragment_byte_code, fragment_code_size);
@@ -243,11 +244,11 @@ int main(int argc, char ** argv)
     uint32_t offset_indices  = vkal_index_buffer_add(rect_indices, index_count);
 
     /* Texture Data */
-    Image image = load_image_file("../../src/examples/assets/textures/vklogo.jpg");
+    Image image = load_image_file("/../src/examples/assets/textures/vklogo.jpg");
     VkalTexture texture = vkal_create_texture(0, image.data, image.width, image.height, 4, 0,
 					  VK_IMAGE_VIEW_TYPE_2D, VK_FORMAT_R8G8B8A8_UNORM, 0, 1, 0, 1, VK_FILTER_LINEAR, VK_FILTER_LINEAR,
 					  VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER);
-    Image image2 = load_image_file("../../src/examples/assets/textures/hk.jpg");
+    Image image2 = load_image_file("/../src/examples/assets/textures/hk.jpg");
     VkalTexture texture2 = vkal_create_texture(0, image2.data, image2.width, image2.height, 4, 0,
 					   VK_IMAGE_VIEW_TYPE_2D, VK_FORMAT_R8G8B8A8_UNORM, 0, 1, 0, 1, VK_FILTER_LINEAR, VK_FILTER_LINEAR,
 					   VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER);

--- a/src/examples/GLFW_MultipleTexturesNaive/textures.cpp
+++ b/src/examples/GLFW_MultipleTexturesNaive/textures.cpp
@@ -79,17 +79,18 @@ void init_window()
     //glfwSetFramebufferSizeCallback(window, glfw_framebuffer_size_callback);
 }
 
+// TODO: Move this function into utility as it is used by multiple examples.
 Image load_image_file(char const * file)
 {
     char exe_path[256];
-    get_exe_path(exe_path, 256 * sizeof(char));
-    char abs_path[256];
-    memcpy(abs_path, exe_path, 256);
-    strcat(abs_path, file);
+    get_exe_path(exe_path, 256 * sizeof(char));    
+    // strcat(abs_path, file);
+    std::string finalPath = concat_paths(std::string(exe_path), std::string(file));
 
-    Image image = {0};
+
+    Image image = { };
     int tw, th, tn;
-    image.data = stbi_load(abs_path, &tw, &th, &tn, 4);
+    image.data = stbi_load(finalPath.c_str(), &tw, &th, &tn, 4);
     assert(image.data != NULL);
     image.width = tw;
     image.height = th;

--- a/src/examples/GLFW_MultipleTexturesNaive/textures.cpp
+++ b/src/examples/GLFW_MultipleTexturesNaive/textures.cpp
@@ -110,18 +110,22 @@ int main(int argc, char ** argv)
     };
     uint32_t device_extension_count = sizeof(device_extensions) / sizeof(*device_extensions);
 
-    char * instance_extensions[] = {
-	VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME,
-    VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME
-#ifdef _DEBUG
-	,VK_EXT_DEBUG_UTILS_EXTENSION_NAME
-#endif
+    char* instance_extensions[] = {
+        VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME
+        #ifdef __APPLE__
+            ,VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME
+        #endif
+        #ifdef _DEBUG
+            ,VK_EXT_DEBUG_UTILS_EXTENSION_NAME
+        #endif
     };
     uint32_t instance_extension_count = sizeof(instance_extensions) / sizeof(*instance_extensions);
 
-    char * instance_layers[] = {
-	"VK_LAYER_KHRONOS_validation", //"VK_LAYER_LUNARG_standard_validation", <- deprecated!
-	"VK_LAYER_LUNARG_monitor"
+    char* instance_layers[] = {
+        "VK_LAYER_KHRONOS_validation"
+#if defined(WIN32) || defined(WIN32)
+        ,"VK_LAYER_LUNARG_monitor" // Not available on MacOS!
+#endif
     };
     uint32_t instance_layer_count = 0;
 #ifdef _DEBUG

--- a/src/examples/GLFW_Primitives/primitives.cpp
+++ b/src/examples/GLFW_Primitives/primitives.cpp
@@ -182,17 +182,22 @@ int main(int argc, char ** argv)
     };
     uint32_t device_extension_count = sizeof(device_extensions) / sizeof(*device_extensions);
 
-    char * instance_extensions[] = {
-	VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME
-#ifdef _DEBUG
-	,VK_EXT_DEBUG_UTILS_EXTENSION_NAME
-#endif
+    char* instance_extensions[] = {
+        VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME
+        #ifdef __APPLE__
+            ,VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME
+        #endif
+        #ifdef _DEBUG
+            ,VK_EXT_DEBUG_UTILS_EXTENSION_NAME
+        #endif
     };
     uint32_t instance_extension_count = sizeof(instance_extensions) / sizeof(*instance_extensions);
 
-    char * instance_layers[] = {
-	"VK_LAYER_KHRONOS_validation",
-	//"VK_LAYER_LUNARG_monitor"
+    char* instance_layers[] = {
+        "VK_LAYER_KHRONOS_validation"
+#if defined(WIN32) || defined(WIN32)
+        ,"VK_LAYER_LUNARG_monitor" // Not available on MacOS!
+#endif
     };
     uint32_t instance_layer_count = 0;
 #ifdef _DEBUG

--- a/src/examples/GLFW_PrimitivesDynamic/primitives_dynamic.cpp
+++ b/src/examples/GLFW_PrimitivesDynamic/primitives_dynamic.cpp
@@ -637,17 +637,22 @@ int main(int argc, char ** argv)
     };
     uint32_t device_extension_count = sizeof(device_extensions) / sizeof(*device_extensions);
 
-    char * instance_extensions[] = {
-	VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME
-#ifdef _DEBUG
-	,VK_EXT_DEBUG_UTILS_EXTENSION_NAME
-#endif
+    char* instance_extensions[] = {
+        VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME
+        #ifdef __APPLE__
+            ,VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME
+        #endif
+        #ifdef _DEBUG
+            ,VK_EXT_DEBUG_UTILS_EXTENSION_NAME
+        #endif
     };
     uint32_t instance_extension_count = sizeof(instance_extensions) / sizeof(*instance_extensions);
 
-    char * instance_layers[] = {
-	"VK_LAYER_KHRONOS_validation",
-	"VK_LAYER_LUNARG_monitor"
+    char* instance_layers[] = {
+        "VK_LAYER_KHRONOS_validation"
+#if defined(WIN32) || defined(WIN32)
+        ,"VK_LAYER_LUNARG_monitor" // Not available on MacOS!
+#endif
     };
     uint32_t instance_layer_count = 0;
 #ifdef _DEBUG

--- a/src/examples/GLFW_Raytracing/raytracing.cpp
+++ b/src/examples/GLFW_Raytracing/raytracing.cpp
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 
 #include <vector>
+#include <string>
 
 #include <vkal.h>
 
@@ -104,12 +105,11 @@ Image load_image(const char* file)
 
     char exe_path[256];
     get_exe_path(exe_path, 256 * sizeof(char));
-    char abs_path[256];
-    memcpy(abs_path, exe_path, 256);
-    strcat(abs_path, file);
+    std::string finalPath = concat_paths(std::string(exe_path), std::string(file));
 
+ 
     int width, height, channels;
-    unsigned char* data = stbi_load(abs_path, &width, &height, &channels, 4);
+    unsigned char* data = stbi_load(finalPath.c_str(), &width, &height, &channels, 4);
     if (stbi_failure_reason() != NULL) {
         printf("[STB-Image] %s file: %s\n", stbi_failure_reason(), file);
     }

--- a/src/examples/GLFW_Raytracing/raytracing.cpp
+++ b/src/examples/GLFW_Raytracing/raytracing.cpp
@@ -1132,8 +1132,10 @@ int main(int argc, char** argv)
     wanted_features.features12.shaderStorageBufferArrayNonUniformIndexing = VK_TRUE;
     wanted_features.rayTracingPipelineFeatures.rayTracingPipeline = VK_TRUE;
     wanted_features.accelerationStructureFeatures.accelerationStructure = VK_TRUE;
-    VkalInfo* vkal_info = vkal_init(device_extensions, device_extension_count, wanted_features);
+    
     vkal_init_raytracing();
+
+    VkalInfo* vkal_info = vkal_init(device_extensions, device_extension_count, wanted_features);    
 
     /* Textures */
     Image sandImage = load_image("../../src/examples/assets/textures/sand_diffuse.jpg");

--- a/src/examples/GLFW_RenderToTexture/rendertexture.cpp
+++ b/src/examples/GLFW_RenderToTexture/rendertexture.cpp
@@ -45,17 +45,18 @@ void init_window()
     //glfwSetFramebufferSizeCallback(window, glfw_framebuffer_size_callback);
 }
 
+// TODO: Move this function into utility as it is used by multiple examples.
 Image load_image_file(char const * file)
 {
     char exe_path[256];
-    get_exe_path(exe_path, 256 * sizeof(char));
-    char abs_path[256];
-    memcpy(abs_path, exe_path, 256);
-    strcat(abs_path, file);
+    get_exe_path(exe_path, 256 * sizeof(char));    
+    // strcat(abs_path, file);
+    std::string finalPath = concat_paths(std::string(exe_path), std::string(file));
+
 
     Image image = { };
     int tw, th, tn;
-    image.data = stbi_load(abs_path, &tw, &th, &tn, 4);
+    image.data = stbi_load(finalPath.c_str(), &tw, &th, &tn, 4);
     assert(image.data != NULL);
     image.width = tw;
     image.height = th;

--- a/src/examples/GLFW_RenderToTexture/rendertexture.cpp
+++ b/src/examples/GLFW_RenderToTexture/rendertexture.cpp
@@ -76,17 +76,22 @@ int main(int argc, char ** argv)
     };
     uint32_t device_extension_count = sizeof(device_extensions) / sizeof(*device_extensions);
 
-    char * instance_extensions[] = {
-	VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME
-#ifdef _DEBUG
-	,VK_EXT_DEBUG_UTILS_EXTENSION_NAME
-#endif
+    char* instance_extensions[] = {
+        VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME
+        #ifdef __APPLE__
+            ,VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME
+        #endif
+        #ifdef _DEBUG
+            ,VK_EXT_DEBUG_UTILS_EXTENSION_NAME
+        #endif
     };
     uint32_t instance_extension_count = sizeof(instance_extensions) / sizeof(*instance_extensions);
 
-    char * instance_layers[] = {
-	"VK_LAYER_KHRONOS_validation", //"VK_LAYER_LUNARG_standard_validation", <- deprecated!
-	"VK_LAYER_LUNARG_monitor"
+    char* instance_layers[] = {
+        "VK_LAYER_KHRONOS_validation"
+#if defined(WIN32) || defined(WIN32)
+        ,"VK_LAYER_LUNARG_monitor" // Not available on MacOS!
+#endif
     };
     uint32_t instance_layer_count = 0;
 #ifdef _DEBUG

--- a/src/examples/GLFW_Texture/texture.cpp
+++ b/src/examples/GLFW_Texture/texture.cpp
@@ -94,17 +94,22 @@ int main(int argc, char ** argv)
     };
     uint32_t device_extension_count = sizeof(device_extensions) / sizeof(*device_extensions);
 
-    char * instance_extensions[] = {
-	VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME
-#ifdef _DEBUG
-	,VK_EXT_DEBUG_UTILS_EXTENSION_NAME
-#endif
+    char* instance_extensions[] = {
+        VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME
+        #ifdef __APPLE__
+            ,VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME
+        #endif
+        #ifdef _DEBUG
+            ,VK_EXT_DEBUG_UTILS_EXTENSION_NAME
+        #endif
     };
     uint32_t instance_extension_count = sizeof(instance_extensions) / sizeof(*instance_extensions);
 
-    char * instance_layers[] = {
-	"VK_LAYER_KHRONOS_validation"
-	//"VK_LAYER_LUNARG_monitor" // TODO: Not available on MacOS ?
+    char* instance_layers[] = {
+        "VK_LAYER_KHRONOS_validation"
+#if defined(WIN32) || defined(WIN32)
+        ,"VK_LAYER_LUNARG_monitor" // Not available on MacOS!
+#endif
     };
     uint32_t instance_layer_count = 0;
 #ifdef _DEBUG

--- a/src/examples/GLFW_TextureDescriptorArray/textures_descriptorarray_push_constant.cpp
+++ b/src/examples/GLFW_TextureDescriptorArray/textures_descriptorarray_push_constant.cpp
@@ -54,17 +54,18 @@ void init_window()
     //glfwSetFramebufferSizeCallback(window, glfw_framebuffer_size_callback);
 }
 
+// TODO: Move this function into utility as it is used by multiple examples.
 Image load_image_file(char const * file)
 {
     char exe_path[256];
-    get_exe_path(exe_path, 256 * sizeof(char));
-    char abs_path[256];
-    memcpy(abs_path, exe_path, 256);
-    strcat(abs_path, file);
+    get_exe_path(exe_path, 256 * sizeof(char));    
+    // strcat(abs_path, file);
+    std::string finalPath = concat_paths(std::string(exe_path), std::string(file));
 
-    Image image = {0};
+
+    Image image = { };
     int tw, th, tn;
-    image.data = stbi_load(abs_path, &tw, &th, &tn, 4);
+    image.data = stbi_load(finalPath.c_str(), &tw, &th, &tn, 4);
     assert(image.data != NULL);
     image.width = tw;
     image.height = th;

--- a/src/examples/GLFW_TextureDescriptorArray/textures_descriptorarray_push_constant.cpp
+++ b/src/examples/GLFW_TextureDescriptorArray/textures_descriptorarray_push_constant.cpp
@@ -85,17 +85,22 @@ int main(int argc, char ** argv)
     };
     uint32_t device_extension_count = sizeof(device_extensions) / sizeof(*device_extensions);
 
-    char * instance_extensions[] = {
-	VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME
-#ifdef _DEBUG
-	,VK_EXT_DEBUG_UTILS_EXTENSION_NAME
-#endif
+    char* instance_extensions[] = {
+        VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME
+        #ifdef __APPLE__
+            ,VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME
+        #endif
+        #ifdef _DEBUG
+            ,VK_EXT_DEBUG_UTILS_EXTENSION_NAME
+        #endif
     };
     uint32_t instance_extension_count = sizeof(instance_extensions) / sizeof(*instance_extensions);
 
-    char * instance_layers[] = {
-	"VK_LAYER_KHRONOS_validation", //"VK_LAYER_LUNARG_standard_validation", <- deprecated!
-	"VK_LAYER_LUNARG_monitor"
+    char* instance_layers[] = {
+        "VK_LAYER_KHRONOS_validation"
+#if defined(WIN32) || defined(WIN32)
+        ,"VK_LAYER_LUNARG_monitor" // Not available on MacOS!
+#endif
     };
     uint32_t instance_layer_count = 0;
 #ifdef _DEBUG

--- a/src/examples/GLFW_TrueType/ttf_drawing.cpp
+++ b/src/examples/GLFW_TrueType/ttf_drawing.cpp
@@ -299,17 +299,22 @@ int main(int argc, char ** argv)
     };
     uint32_t device_extension_count = sizeof(device_extensions) / sizeof(*device_extensions);
 
-    char * instance_extensions[] = {
-	VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME
-#ifdef _DEBUG
-	,VK_EXT_DEBUG_UTILS_EXTENSION_NAME
-#endif
+    char* instance_extensions[] = {
+        VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME
+        #ifdef __APPLE__
+            ,VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME
+        #endif
+        #ifdef _DEBUG
+            ,VK_EXT_DEBUG_UTILS_EXTENSION_NAME
+        #endif
     };
     uint32_t instance_extension_count = sizeof(instance_extensions) / sizeof(*instance_extensions);
 
-    char * instance_layers[] = {
-	"VK_LAYER_KHRONOS_validation",
-	"VK_LAYER_LUNARG_monitor"
+    char* instance_layers[] = {
+        "VK_LAYER_KHRONOS_validation"
+#if defined(WIN32) || defined(WIN32)
+        ,"VK_LAYER_LUNARG_monitor" // Not available on MacOS!
+#endif
     };
     uint32_t instance_layer_count = 0;
 #ifdef _DEBUG

--- a/src/examples/utils/model_v2.cpp
+++ b/src/examples/utils/model_v2.cpp
@@ -14,16 +14,14 @@ Model create_model_from_file_indexed(char const* file)
 {
 	char exe_path[256];
 	get_exe_path(exe_path, 256 * sizeof(char));
-	char abs_path[256];
-	memcpy(abs_path, exe_path, 256);
-	strcat(abs_path, file);
+	std::string final_path = concat_paths(std::string(exe_path), std::string(file));
 
 	Model model = {};
 	/* Find out how many vertices and indices this model has in total.
 	Assimp makes sure to use multiple vertices per face by the flag 'aiProcess_JoinIdenticalVertices'.
 	So we allocate exactly as much memory as is required for the vertex-buffer.
 	*/
-	aiScene const* scene = aiImportFile(abs_path, aiProcess_Triangulate | aiProcess_FlipUVs | aiProcess_GenBoundingBoxes);
+	aiScene const* scene = aiImportFile(final_path.c_str(), aiProcess_Triangulate | aiProcess_FlipUVs | aiProcess_GenBoundingBoxes);
 	for (int i = 0; i < scene->mNumMeshes; ++i) {
 		model.vertex_count += scene->mMeshes[i]->mNumVertices;
 		for (int f = 0; f < scene->mMeshes[i]->mNumFaces; ++f) {

--- a/src/examples/utils/platform.cpp
+++ b/src/examples/utils/platform.cpp
@@ -85,7 +85,7 @@
 
 /* Platform independent part. Should work on all systems. */
 
-static std::string concat_paths(std::string a, std::string b)
+std::string concat_paths(std::string a, std::string b)
 {
 	size_t lastOfAIdx = a.size() - 1;
     char endOfA = a[lastOfAIdx];
@@ -100,8 +100,13 @@ static std::string concat_paths(std::string a, std::string b)
 		if (startOfB == '/') {
 			a.resize(a.size() - 1);
 		}
-    }
-    
+    }	
+    else {
+		if (startOfB != '/') {
+			a += '/';
+		}
+	}
+
     a += b;
 
     return a;
@@ -137,7 +142,8 @@ std::string read_text_file(char const* filename)
 	get_exe_path(exe_path, 256 * sizeof(char));
 	char abs_path[256];
 	memcpy(abs_path, exe_path, 256);
-	strcat(abs_path, filename);
+	// strcat(abs_path, filename);
+	concat_paths(std::string(abs_path), std::string(filename));
 
 	std::ifstream iFileStream;
 	std::stringstream ss;

--- a/src/examples/utils/platform.cpp
+++ b/src/examples/utils/platform.cpp
@@ -87,11 +87,19 @@
 
 static std::string concat_paths(std::string a, std::string b)
 {
-    char endOfA = a[a.size() - 1];
+	size_t lastOfAIdx = a.size() - 1;
+    char endOfA = a[lastOfAIdx];
     char startOfB = b[0];
 
-    if (endOfA != '/' && startOfB != '/') {
-        a += '/';
+	if (endOfA == '\\') { // On windows, this is a possibility (sadly)
+		if (startOfB == '\\' || startOfB == '/') {
+			a.resize(a.size() - 1);
+		}
+	}    
+	else if (endOfA == '/') { // All systems
+		if (startOfB == '/') {
+			a.resize(a.size() - 1);
+		}
     }
     
     a += b;

--- a/src/examples/utils/platform.cpp
+++ b/src/examples/utils/platform.cpp
@@ -85,14 +85,36 @@
 
 /* Platform independent part. Should work on all systems. */
 
+static std::string concat_paths(std::string a, std::string b)
+{
+    char endOfA = a[a.size() - 1];
+    char startOfB = b[0];
+
+    if (endOfA != '/' && startOfB != '/') {
+        a += '/';
+    }
+    
+    a += b;
+
+    return a;
+}
+
 void read_file(char const* filename, uint8_t** out_buffer, int* out_size)
 {
 	char exe_path[256];
 	get_exe_path(exe_path, 256 * sizeof(char));
 	char abs_path[256];
 	memcpy(abs_path, exe_path, 256);
-	strcat(abs_path, filename);
-	FILE* file = fopen(abs_path, "rb");
+    std::string final_path = concat_paths(std::string(exe_path), std::string(filename));
+	//strcat(abs_path, filename);
+	FILE* file = fopen(final_path.c_str(), "rb");
+    if (!file) {
+        fprintf(stderr, "Failed to read file: %s\n", final_path.c_str());
+        *out_buffer = NULL;
+        *out_size = 0;
+        
+        return;
+    }
 	fseek(file, 0L, SEEK_END);
 	*out_size = ftell(file);
 	fseek(file, 0L, SEEK_SET);

--- a/src/examples/utils/platform.h
+++ b/src/examples/utils/platform.h
@@ -8,6 +8,6 @@
 void		read_file(char const * filename, uint8_t ** out_buffer, int * out_size);
 std::string read_text_file(char const* filename);
 void		get_exe_path(char * out_buffer, int buffer_size);
-
+std::string concat_paths(std::string a, std::string b);
 
 #endif

--- a/vkal.c
+++ b/vkal.c
@@ -85,6 +85,8 @@ VkalInfo * vkal_init(char ** extensions, uint32_t extension_count, VkalWantedFea
     create_default_semaphores();
     vkal_info.frames_rendered = 0;
 
+    printf("vkal_init: done.\n");
+
 
     return &vkal_info;
 }
@@ -122,6 +124,7 @@ void vkal_create_instance_glfw(
     char ** instance_extensions, uint32_t instance_extension_count,
     char ** instance_layers, uint32_t instance_layer_count)
 {
+    printf("Init GLFW instance...\n");
     vkal_info.window = window;
     VkApplicationInfo app_info = {0};
     app_info.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
@@ -129,7 +132,7 @@ void vkal_create_instance_glfw(
     app_info.applicationVersion = VK_MAKE_VERSION(1, 0, 0);
     app_info.pEngineName = "VKAL Engine";
     app_info.engineVersion = VK_MAKE_VERSION(1, 0, 0);
-    app_info.apiVersion = VK_API_VERSION_1_3;
+    app_info.apiVersion = VK_API_VERSION_1_2;
     
     VkInstanceCreateInfo create_info = {0};
     create_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
@@ -203,6 +206,7 @@ void vkal_create_instance_glfw(
 		}
 		create_info.enabledExtensionCount = total_instance_ext_count;
 		create_info.ppEnabledExtensionNames = (const char * const *)all_instance_extensions;
+        create_info.flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
     
         VkResult result = vkCreateInstance(&create_info, 0, &vkal_info.instance);
 		VKAL_ASSERT(result && "failed to create VkInstance");
@@ -228,7 +232,7 @@ void vkal_create_instance_win32(
 	app_info.applicationVersion = VK_MAKE_VERSION(1, 0, 0);
 	app_info.pEngineName = "VKAL Engine";
 	app_info.engineVersion = VK_MAKE_VERSION(1, 0, 0);
-	app_info.apiVersion = VK_API_VERSION_1_3;
+	app_info.apiVersion = VK_API_VERSION_1_2;
 
 	VkInstanceCreateInfo create_info = { 0 };
 	create_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
@@ -914,8 +918,10 @@ void create_swapchain(void)
     
     VkSurfaceFormatKHR surface_format = choose_swapchain_surface_format(swap_chain_support.formats, swap_chain_support.format_count);
     VkPresentModeKHR present_mode = choose_swapchain_present_mode(swap_chain_support.present_modes, swap_chain_support.present_mode_count);
+    printf("choose_swap_extend...\n");
     VkExtent2D extent = choose_swap_extent(&swap_chain_support.capabilities);
-    
+    printf("done.\n");
+
     uint32_t image_count = VKAL_MAX_SWAPCHAIN_IMAGES;
     if (swap_chain_support.capabilities.maxImageCount > 0) {
 		image_count = VKAL_MIN(image_count, swap_chain_support.capabilities.maxImageCount);
@@ -961,6 +967,8 @@ void create_swapchain(void)
     
     vkal_info.swapchain_image_format = surface_format.format;
     vkal_info.swapchain_extent = extent;
+
+    printf("create_swapchain: done.\n");
 }
 
 void create_image_views(void)

--- a/vkal.c
+++ b/vkal.c
@@ -134,7 +134,7 @@ void vkal_create_instance_glfw(
     #if defined (Win32) || defined(__linux__)
         app_info.apiVersion = VK_API_VERSION_1_3;
     #elif __APPLE__
-        app_info.apiVersion = VK_API_VERSION_1_2; // MoltonVK only goes up to Vulkan version 1.2
+        app_info.apiVersion = VK_API_VERSION_1_2; // MoltenVK only goes up to Vulkan version 1.2
     #endif
     
     VkInstanceCreateInfo create_info = {0};
@@ -344,7 +344,7 @@ void vkal_create_instance_sdl(
     #if defined (Win32) || defined(__linux__)
         app_info.apiVersion = VK_API_VERSION_1_3;
     #elif __APPLE__
-        app_info.apiVersion = VK_API_VERSION_1_2; // MoltonVK only goes up to Vulkan version 1.2
+        app_info.apiVersion = VK_API_VERSION_1_2; // MoltenVK only goes up to Vulkan version 1.2
     #endif
 
     VkInstanceCreateInfo create_info = { 0 };

--- a/vkal.c
+++ b/vkal.c
@@ -131,7 +131,7 @@ void vkal_create_instance_glfw(
     app_info.applicationVersion = VK_MAKE_VERSION(1, 0, 0);
     app_info.pEngineName = "VKAL Engine";
     app_info.engineVersion = VK_MAKE_VERSION(1, 0, 0);
-    #if defined (Win32) || defined(__linux__)
+    #if defined (WIN32) || defined(__linux__)
         app_info.apiVersion = VK_API_VERSION_1_3;
     #elif __APPLE__
         app_info.apiVersion = VK_API_VERSION_1_2; // MoltenVK only goes up to Vulkan version 1.2
@@ -341,7 +341,7 @@ void vkal_create_instance_sdl(
     app_info.applicationVersion = VK_MAKE_VERSION(1, 0, 0);
     app_info.pEngineName = "VKAL Engine";
     app_info.engineVersion = VK_MAKE_VERSION(1, 0, 0);
-    #if defined (Win32) || defined(__linux__)
+    #if defined (WIN32) || defined(__linux__)
         app_info.apiVersion = VK_API_VERSION_1_3;
     #elif __APPLE__
         app_info.apiVersion = VK_API_VERSION_1_2; // MoltenVK only goes up to Vulkan version 1.2

--- a/vkal.h
+++ b/vkal.h
@@ -299,7 +299,7 @@ typedef struct VkalInfo
     uint32_t		depth_stencil_image_view;
     uint32_t		device_memory_depth_stencil;
 
-    VkDeviceMemory	device_memory_staging;
+    VkDeviceMemory	    device_memory_staging;
     VkalBuffer			staging_buffer;
 
     VkRenderPass		render_pass;
@@ -332,6 +332,8 @@ typedef struct VkalInfo
     uint64_t		default_index_buffer_offset;
 
     VkDescriptorPool default_descriptor_pool;
+
+    uint32_t        raytracing_enabled;
 } VkalInfo;
 
 typedef struct QueueFamilyIndicies {


### PR DESCRIPTION
Add MacOS specific code to both vkal and the GLFW examples:

# VKAL
- Add 
```c
  #ifdef __APPLE__
      create_info.flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
  #endif
```
when creating the VkInstance. 

# GLFW examples
- Add ```VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME``` to all GLFW examples' instance extension list (except raytracing example).

Also, some code was added to ```platform.cpp``` which hopefully solves a few issues with loading files on different systems.
